### PR TITLE
Update OS name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 ## Description:
 
- The `MacTypes-sys` library provides bindings to the MacTypes.h header on OSX.
+ The `MacTypes-sys` library provides bindings to the MacTypes.h header on macOS.
 This library defines base types used in both Carbon and legacy Cocoa APIs.
 
 ## Usage:


### PR DESCRIPTION
This change is a few OS releases old now, newer users won't search for OSX, or OS X, but mac or macOS.